### PR TITLE
Add dependbot to keep GitHub Action up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files in .github/workflows will be checked
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
- Lets stay with the times with out GitHub actions ...

Expect PRs to come when we merge.